### PR TITLE
Web 8 updates for version 1.1

### DIFF
--- a/RealTimePublishingStatus/Controllers/QueueServiceController.cs
+++ b/RealTimePublishingStatus/Controllers/QueueServiceController.cs
@@ -1,7 +1,6 @@
 ﻿using Alchemy4Tridion.Plugins;
 using System;
 using System.Linq;
-using System.Net.Http;
 using System.Text;
 using System.Web.Http;
 using Tridion.ContentManager.CoreService.Client;

--- a/RealTimePublishingStatus/GUI/RealTimePublishingStatusCommandSet.cs
+++ b/RealTimePublishingStatus/GUI/RealTimePublishingStatusCommandSet.cs
@@ -1,9 +1,4 @@
 ﻿using Alchemy4Tridion.Plugins.GUI.Configuration;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace RealTimePublishingStatus.GUI
 {
@@ -12,7 +7,6 @@ namespace RealTimePublishingStatus.GUI
         public RealTimePublishingStatusCommandSet()
         {
             AddCommand("OpenRealTimePublishingQueue");
-            AddCommand("Queue");
         }
     }
 

--- a/RealTimePublishingStatus/GUI/ResourceGroups/RealTimePublishingStatusResourceGroup.cs
+++ b/RealTimePublishingStatus/GUI/ResourceGroups/RealTimePublishingStatusResourceGroup.cs
@@ -1,9 +1,4 @@
 ﻿using Alchemy4Tridion.Plugins.GUI.Configuration;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace RealTimePublishingStatus.GUI.ResourceGroups
 {
@@ -13,19 +8,10 @@ namespace RealTimePublishingStatus.GUI.ResourceGroups
         {
             //Add the Js files
             AddFile("OpenRealTimePublishingQueue.js");
-            AddFile("QueueCommand.js");
 
-            //Add the CSS
-            AddFile("RealTimePublishingQueuePopup.css");
             AddFile("RealTimePublishingQueueStyles.css");
 
-            //Add the images
-            AddFile("icon-16x16.png");
-            AddFile("icon-32x32.png");
-
             AddFile<RealTimePublishingStatusCommandSet>();
-            AddWebApiProxy();
-            AttachToView("PublishQueue.aspx");
         }
     }
 }

--- a/RealTimePublishingStatus/GUI/ResourceGroups/RealTimePublishingStatusViewResourceGroup.cs
+++ b/RealTimePublishingStatus/GUI/ResourceGroups/RealTimePublishingStatusViewResourceGroup.cs
@@ -1,0 +1,16 @@
+﻿using Alchemy4Tridion.Plugins.GUI.Configuration;
+
+namespace RealTimePublishingStatus.GUI.ResourceGroups
+{
+    public class RealTimePublishingStatusViewResourceGroup : ResourceGroup
+    {
+        public RealTimePublishingStatusViewResourceGroup()
+        {
+            //Add the CSS
+            AddFile("RealTimePublishingQueuePopup.css");
+
+            AddWebApiProxy();
+            AttachToView("PublishQueue.aspx");
+        }
+    }
+}

--- a/RealTimePublishingStatus/GUI/RibbonToolbar/SingleButton.cs
+++ b/RealTimePublishingStatus/GUI/RibbonToolbar/SingleButton.cs
@@ -1,10 +1,5 @@
 ﻿using Alchemy4Tridion.Plugins.GUI.Configuration;
 using RealTimePublishingStatus.GUI.ResourceGroups;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace RealTimePublishingStatus.GUI.RibbonToolbar
 {
@@ -19,7 +14,7 @@ namespace RealTimePublishingStatus.GUI.RibbonToolbar
             // which tab to put it on
             PageId = Constants.PageIds.HomePage;
             // Which group to put it on... in this case we're adding it to the publish group
-            GroupId = "PublishGroup";
+            GroupId = Constants.GroupIds.HomePage.PublishGroup;
 
             // the command to execute when clicked..
             Command = "OpenRealTimePublishingQueue";

--- a/RealTimePublishingStatus/RealTimePublishingStatus.csproj
+++ b/RealTimePublishingStatus/RealTimePublishingStatus.csproj
@@ -42,7 +42,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Alchemy4Tridion.Plugins, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Alchemy4Tridion.Plugin.1.0.0-beta6-2\lib\net40\Alchemy4Tridion.Plugins.dll</HintPath>
+      <HintPath>..\packages\Alchemy4Tridion.Plugin.1.0.0-beta7-0\lib\net40\Alchemy4Tridion.Plugins.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -72,7 +72,7 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="Tridion.ContentManager.CoreService.Client, Version=7.1.0.1290, Culture=neutral, PublicKeyToken=ddfc895746e5ee6b, processorArchitecture=MSIL">
-      <HintPath>..\packages\Alchemy4Tridion.Plugin.1.0.0-beta6-2\lib\net40\Tridion.ContentManager.CoreService.Client.dll</HintPath>
+      <HintPath>..\packages\Alchemy4Tridion.Plugin.1.0.0-beta7-0\lib\net40\Tridion.ContentManager.CoreService.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -81,6 +81,7 @@
     <Compile Include="Controllers\QueueServiceController.cs" />
     <Compile Include="GUI\RealTimePublishingStatusCommandSet.cs" />
     <Compile Include="GUI\ResourceGroups\RealTimePublishingStatusResourceGroup.cs" />
+    <Compile Include="GUI\ResourceGroups\RealTimePublishingStatusViewResourceGroup.cs" />
     <Compile Include="GUI\RibbonToolbar\SingleButton.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RealTimePubStatus.cs" />
@@ -103,12 +104,12 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Alchemy4Tridion.Plugin.1.0.0-beta6-2\build\net40\Alchemy4Tridion.Plugin.targets" Condition="Exists('..\packages\Alchemy4Tridion.Plugin.1.0.0-beta6-2\build\net40\Alchemy4Tridion.Plugin.targets')" />
+  <Import Project="..\packages\Alchemy4Tridion.Plugin.1.0.0-beta7-0\build\net40\Alchemy4Tridion.Plugin.targets" Condition="Exists('..\packages\Alchemy4Tridion.Plugin.1.0.0-beta7-0\build\net40\Alchemy4Tridion.Plugin.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Alchemy4Tridion.Plugin.1.0.0-beta6-2\build\net40\Alchemy4Tridion.Plugin.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Alchemy4Tridion.Plugin.1.0.0-beta6-2\build\net40\Alchemy4Tridion.Plugin.targets'))" />
+    <Error Condition="!Exists('..\packages\Alchemy4Tridion.Plugin.1.0.0-beta7-0\build\net40\Alchemy4Tridion.Plugin.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Alchemy4Tridion.Plugin.1.0.0-beta7-0\build\net40\Alchemy4Tridion.Plugin.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/RealTimePublishingStatus/Static/Views/PublishQueue.aspx
+++ b/RealTimePublishingStatus/Static/Views/PublishQueue.aspx
@@ -5,18 +5,21 @@
     <title>Real Time Publish Queue</title>
     <!-- TODO: Move this to onready or similar -->
     <script src="${JsUrl}/jquery-2.1.4.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="${CssUrl}/RealTimePublishingQueuePopup.css" />
     <script>
         jQuery(document).ready(function () {
             myInitializeCode();
-            window.setInterval(function () {
-                myInitializeCode();
-            }, 5000);
         });
 
-
-
         function myInitializeCode() {
+            if (!window.Alchemy) {
+                // resources have not loaded yet... let's wait...
+                window.setTimeout(myInitializeCode, 500);
+                return;
+            }
+            window.setInterval(getRealTimeItemsFromQueue, 5000);
+        }
+
+        function getRealTimeItemsFromQueue() {
             Alchemy.Plugins.Real_Time_Publish_Queue.Api.QueueService.getQueue(function (error, response) { if (error) jQuery("#message").text(error); else jQuery("#message").html(response); });
         }
     </script>

--- a/RealTimePublishingStatus/Static/Views/PublishQueue.aspx
+++ b/RealTimePublishingStatus/Static/Views/PublishQueue.aspx
@@ -16,6 +16,7 @@
                 window.setTimeout(myInitializeCode, 500);
                 return;
             }
+            getRealTimeItemsFromQueue();
             window.setInterval(getRealTimeItemsFromQueue, 5000);
         }
 

--- a/RealTimePublishingStatus/a4t.xml
+++ b/RealTimePublishingStatus/a4t.xml
@@ -6,5 +6,5 @@
   <version>1.0.0.1</version>
   <versionId>56093937e4de0211ecfc1c60</versionId>
   <frameworkVersion>0.6.2.0</frameworkVersion>
-  <buildTime>2015-09-30T20:08:11.8505035+01:00</buildTime>
+  <buildTime>2015-09-30T15:08:11.8505035-04:00</buildTime>
 </plugin>

--- a/RealTimePublishingStatus/packages.config
+++ b/RealTimePublishingStatus/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Alchemy4Tridion.Plugin" version="1.0.0-beta6-2" targetFramework="net452" />
+  <package id="Alchemy4Tridion.Plugin" version="1.0.0-beta7-0" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net452" />


### PR DESCRIPTION
There was some issues when installing the plugin in SDL Web 8.

Made the following updates to the plugin source code if you'd like to pull it in, upload, and submit a version 1.1 of your plugin!  Here's a list of the changes:
- Removed image references from the Resource Group (was ignored in 2013, throws error in Web 8).
- Removed Queue js file from Resource Group (looks like this command was not used anywhere)
- Removed Queue command from Command Set
- Removed AttachToView, WebApiProxy from Resource Group
- Added new View Resource Group (added css, AttachToView, and WebApiProxy to this ResourceGroup) - this is the group we want to load into our popup
- Removed the css ref from the aspx file (as our resource group loads this). I kept jquery manually added in the aspx rather than resource group as Tridion's minification does weird things with it sometimes. Note that it is now unaffected by the Tridion resource bundler/minifier.
- Updated to A4T 0.8 NuGet package
- Updated GroupId in Ribbon Toolbar button to use Constant rather than string
- Added check for "Alchemy" in the interval js function (Web 8 loads resources ajax'y, so we need to ensure our resources exist prior to attempting to perform the polling)

Feel free to contact me if you have any questions about the changes or the process to get the new version uploaded into the webstore.

Thanks!
